### PR TITLE
fix: contact link clickable area

### DIFF
--- a/src/components/Contact/List.scss
+++ b/src/components/Contact/List.scss
@@ -46,6 +46,10 @@
       &:nth-child(odd) {
         margin-right: 20%;
       }
+
+      a {
+        display: inline;
+      }
     }
   }
 }

--- a/src/components/Contact/List.scss
+++ b/src/components/Contact/List.scss
@@ -16,6 +16,10 @@
       transform: scale(1.2);
     }
 
+    a {
+      display: block;
+    }
+
     span {
       margin-left: 0.2rem;
     }


### PR DESCRIPTION
In contact item only central element is clickable:
<img width="527" alt="Screenshot 2024-04-05 at 09 17 51" src="https://github.com/agm1n/awesome-cv-builder/assets/32534833/f020adba-34fa-4b22-97b9-d6fa75e45eb7">


This PR fixes it and makes clickable full square area:
<img width="522" alt="Screenshot 2024-04-05 at 09 18 26" src="https://github.com/agm1n/awesome-cv-builder/assets/32534833/47546a29-b958-4ecb-aeb1-0c21240444c4">
